### PR TITLE
Add Plausible analytics tracking to the site

### DIFF
--- a/site/src/app.html
+++ b/site/src/app.html
@@ -5,6 +5,7 @@
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		%sveltekit.head%
+		<script defer data-domain="diaria.frytea.com" src="https://plausible.frytea.com/js/script.js"></script>
 	</head>
 	<body data-sveltekit-preload-data="hover">
 		<div style="display: contents">%sveltekit.body%</div>


### PR DESCRIPTION
## Summary
This PR adds Plausible analytics tracking to the application by integrating the Plausible script into the main HTML template.

## Changes
- Added Plausible analytics script tag to `site/src/app.html`
  - Script is configured for the domain `diaria.frytea.com`
  - Uses deferred loading to avoid blocking page rendering
  - Points to the self-hosted Plausible instance at `https://plausible.frytea.com`

## Implementation Details
The script is placed in the `<head>` section with the `defer` attribute, ensuring it loads asynchronously without impacting page load performance. This enables privacy-focused analytics tracking for the Diaria application without relying on third-party analytics providers.

https://claude.ai/code/session_01MGJ9H1MaAQxdxJD7woey91