### PR TITLE
Add Google Analytics tracking to site

### DIFF
--- a/site/src/app.html
+++ b/site/src/app.html
@@ -5,6 +5,14 @@
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		%sveltekit.head%
+		<!-- Google tag (gtag.js) -->
+		<script async src="https://www.googletagmanager.com/gtag/js?id=G-37J0W7DESF"></script>
+		<script>
+			window.dataLayer = window.dataLayer || [];
+			function gtag(){dataLayer.push(arguments);}
+			gtag('js', new Date());
+			gtag('config', 'G-37J0W7DESF');
+		</script>
 		<script>
 			document.write('<script defer data-domain="diarum.frytea.com" event-domain="' + window.location.hostname + '" src="https://plausible.frytea.com/js/script.pageview-props.js"><\/script>');
 		</script>


### PR DESCRIPTION
## Summary
This PR adds Google Analytics (GA4) tracking to the site by integrating the Google tag manager script into the main app template.

## Changes
- Added Google Analytics 4 tracking script with measurement ID `G-37J0W7DESF` to `site/src/app.html`
- Implemented the standard gtag.js initialization code to enable page view tracking and event collection
- Script is loaded asynchronously to minimize impact on page load performance

## Implementation Details
- The Google tag manager script is placed in the `<head>` section alongside existing analytics (Plausible)
- Uses the async script loading pattern to prevent blocking page rendering
- Initializes the data layer and configures GA4 with the provided measurement ID
- Both Google Analytics and Plausible analytics are now active on the site for comprehensive tracking

https://claude.ai/code/session_01C84bg75haXqzZiVi7kEujK